### PR TITLE
Main class definition for core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,4 +17,20 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.wildfly.deptreediff.core.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Main class definition for core

Fix to be compliant with README.md instructions:
Run java -jar dep-tree-diff-core-<VERSION>.jar /some/where/original-deps.txt /some/where/changed-deps.txt and get reports of: 