### PR TITLE
Support for minor and micro version updates

### DIFF
--- a/core/src/main/java/org/wildfly/deptreediff/core/DepTreeDiffReporter.java
+++ b/core/src/main/java/org/wildfly/deptreediff/core/DepTreeDiffReporter.java
@@ -8,7 +8,11 @@ public interface DepTreeDiffReporter {
 
     void addRemovedDependency(String gav) throws Exception;
 
-    void addMajorVersionUpgrade(MajorVersionChange change) throws Exception;
+    void addMajorVersionUpgrade(VersionChange change) throws Exception;
+
+    default void addMinorVersionUpgrade(VersionChange change) throws Exception {}
+
+    default void addMicroVersionUpgrade(VersionChange change) throws Exception {}
 
     void done() throws Exception;
 }

--- a/core/src/main/java/org/wildfly/deptreediff/core/DependencyVersion.java
+++ b/core/src/main/java/org/wildfly/deptreediff/core/DependencyVersion.java
@@ -49,6 +49,27 @@ class DependencyVersion {
         return versionParts.get(0).equals(version1.versionParts.get(0));
     }
 
+    public boolean equalsMinorVersion(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DependencyVersion version1 = (DependencyVersion) o;
+        if (versionParts.size() == 1 && version1.versionParts.size() == 1) return true; // just major version present
+        if (versionParts.size() < 2  || version1.versionParts.size() < 2 ) return false;
+        return versionParts.get(1).equals(version1.versionParts.get(1));
+    }
+
+    public boolean equalsMicroVersion(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DependencyVersion version1 = (DependencyVersion) o;
+        if (versionParts.size() == 1 && version1.versionParts.size() == 1) return true; // just major version present
+        if (versionParts.size() == 2 && version1.versionParts.size() == 2) return true; // just minor version present
+        if (versionParts.size() < 3  || version1.versionParts.size() < 3 ) return false;
+        return versionParts.get(2).equals(version1.versionParts.get(2));
+    }
+
     static DependencyVersion parseVersion(String version) {
         String[] parts = version.split("\\.");
         return new DependencyVersion(version, Arrays.asList(parts));

--- a/core/src/main/java/org/wildfly/deptreediff/core/SystemOutReporter.java
+++ b/core/src/main/java/org/wildfly/deptreediff/core/SystemOutReporter.java
@@ -15,8 +15,18 @@ public class SystemOutReporter implements DepTreeDiffReporter {
     }
 
     @Override
-    public void addMajorVersionUpgrade(MajorVersionChange change) {
+    public void addMajorVersionUpgrade(VersionChange change) {
         System.out.println("Major Upgrade: " + change.getOriginalGavString() + " -> " + change.getNewVersion());
+    }
+
+    @Override
+    public void addMinorVersionUpgrade(VersionChange change) throws Exception {
+        System.out.println("Minor Upgrade: " + change.getOriginalGavString() + " -> " + change.getNewVersion());
+    }
+
+    @Override
+    public void addMicroVersionUpgrade(VersionChange change) throws Exception {
+        System.out.println("Micro Upgrade: " + change.getOriginalGavString() + " -> " + change.getNewVersion());
     }
 
     @Override

--- a/core/src/main/java/org/wildfly/deptreediff/core/VersionChange.java
+++ b/core/src/main/java/org/wildfly/deptreediff/core/VersionChange.java
@@ -3,11 +3,11 @@ package org.wildfly.deptreediff.core;
 /**
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
  */
-public class MajorVersionChange {
+public class VersionChange {
     private final String gavString;
     private final String toVersion;
 
-    MajorVersionChange(Dependency original, Dependency changed) {
+    VersionChange(Dependency original, Dependency changed) {
         this.gavString = original.getGavString();
         this.toVersion = changed.getVersion().getVersion();
     }

--- a/core/src/test/java/org/wildfly/deptreediff/core/TestDiffReporter.java
+++ b/core/src/test/java/org/wildfly/deptreediff/core/TestDiffReporter.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class TestDiffReporter implements DepTreeDiffReporter {
     List<String> addedDepedencies = new ArrayList<>();
     List<String> removedDependecies = new ArrayList<>();
-    List<MajorVersionChange> majorVersionChanges = new ArrayList<>();
+    List<VersionChange> majorVersionChanges = new ArrayList<>();
     boolean doneCalled;
 
     @Override
@@ -23,7 +23,7 @@ public class TestDiffReporter implements DepTreeDiffReporter {
     }
 
     @Override
-    public void addMajorVersionUpgrade(MajorVersionChange majorVersionChange) {
+    public void addMajorVersionUpgrade(VersionChange majorVersionChange) {
         majorVersionChanges.add(majorVersionChange);
     }
 

--- a/reporters/github-labels/src/main/java/org/wildfly/deptreediff/reporter/github/GitHubDiffReporter.java
+++ b/reporters/github-labels/src/main/java/org/wildfly/deptreediff/reporter/github/GitHubDiffReporter.java
@@ -9,7 +9,6 @@ import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -18,7 +17,7 @@ import java.util.Set;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.deptreediff.core.DepTreeDiffReporter;
-import org.wildfly.deptreediff.core.MajorVersionChange;
+import org.wildfly.deptreediff.core.VersionChange;
 
 /**
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
@@ -38,7 +37,7 @@ public class GitHubDiffReporter implements DepTreeDiffReporter {
 
     List<String> newDependencies = new ArrayList<>();
     List<String> removedDependencies = new ArrayList<>();
-    List<MajorVersionChange> majorVersionChanges = new ArrayList<>();
+    List<VersionChange> majorVersionChanges = new ArrayList<>();
 
     @Override
     public void addNewDependency(String gav) {
@@ -57,7 +56,7 @@ public class GitHubDiffReporter implements DepTreeDiffReporter {
     }
 
     @Override
-    public void addMajorVersionUpgrade(MajorVersionChange change) {
+    public void addMajorVersionUpgrade(VersionChange change) {
         majorVersionChanges.add(change);
         if (TRACE) {
             System.out.println("Major Version " + change.getOriginalGavString() + " -> " + change.getNewVersion());
@@ -132,7 +131,7 @@ public class GitHubDiffReporter implements DepTreeDiffReporter {
         }
         if (majorVersionChanges.size() > 0) {
             sb.append("Major Version Changes:\r\n");
-            for (MajorVersionChange change : majorVersionChanges) {
+            for (VersionChange change : majorVersionChanges) {
                 sb.append("* " + change.getOriginalGavString() + " -> " + change.getNewVersion() + "\r\n");
             }
             sb.append("\r\n");


### PR DESCRIPTION
Support for minor and micro version updates

Right now `SystemOutReporter` prints minor and micro version updates.
`GitHubDiffReporter` doesn't do anything with minor and micro version updates as `DepTreeDiffReporter` has default impls doing nothing for minor/micro updates.

I was considering system property to control minor and micro version updates checks, but went ahead with printing them all the time.
