### PR TITLE
Do not use https for the internal Maven repository.

### DIFF
--- a/reporters/github-labels/src/main/resources/wildfly-teamcity-settings.xml
+++ b/reporters/github-labels/src/main/resources/wildfly-teamcity-settings.xml
@@ -55,7 +55,7 @@
                 <repository>
                     <id>brontes-mirror</id>
                     <name>Brontes mirror</name>
-                    <url>https://repository.ci.wildfly.org/content/groups/public/</url>
+                    <url>http://repository.ci.wildfly.org/content/groups/public/</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>
@@ -71,7 +71,7 @@
                 <pluginRepository>
                     <id>brontes-mirror</id>
                     <name>Brontes mirror</name>
-                    <url>https://repository.ci.wildfly.org/content/groups/public/</url>
+                    <url>http://repository.ci.wildfly.org/content/groups/public/</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>


### PR DESCRIPTION
The internal repository does not currently allow secure connections. This is okay as it replicates it data securely and is not exposed publically.